### PR TITLE
add support for a second node id

### DIFF
--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -200,6 +200,21 @@ csp_packet_t *csp_recvfrom(csp_socket_t *socket, uint32_t timeout);
 int csp_sendto(uint8_t prio, uint8_t dest, uint8_t dport, uint8_t src_port, uint32_t opts, csp_packet_t *packet, uint32_t timeout);
 
 /**
+ * Send a packet without previously opening a connection
+ * @param prio CSP_PRIO_x
+ * @param dest destination node
+ * @param dport destination port
+ * @param src source node
+ * @param src_port source port
+ * @param opts CSP_O_x
+ * @param packet pointer to packet
+ * @param timeout timeout used by interfaces with blocking send
+ * @return -1 if error (you must free packet), 0 if OK (you must discard pointer)
+ */
+int csp_sendto_from(uint8_t prio, uint8_t dest, uint8_t dport, uint8_t src, uint8_t src_port, uint32_t opts, csp_packet_t *packet, uint32_t timeout);
+
+
+/**
  * Send a packet as a direct reply to the source of an incoming packet,
  * but still without holding an entire connection
  * @param request_packet pointer to packet to reply to

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -1,7 +1,7 @@
 /*
 Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
 Copyright (C) 2012 Gomspace ApS (http://www.gomspace.com)
-Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk) 
+Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk)
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -42,11 +42,35 @@ extern "C" {
 /** The address of the node */
 extern uint8_t my_address;
 
+/** the dynamic address */
+extern uint8_t my_dynamic_address;
+
+/** is dynamic enabled? */
+extern bool dynamic_address_enabled;
+
 /** csp_init
  * Start up the can-space protocol
  * @param my_node_address The CSP node address
  */
 int csp_init(uint8_t my_node_address);
+
+/** csp_enable_dynamic_address
+ * This node will also act as the node for that address
+ * @param my_node_address The CSP node address
+ */
+int csp_enable_dynamic_address(uint8_t my_node_address);
+
+/** csp_disable_dynamic_address
+ * This node will also stop acting ad the dynamic node
+ */
+int csp_disable_dynamic_address();
+
+/** csp_is_address_mine
+ * Is this one of my addresses?
+ * @param address The CSP node address
+ */
+
+bool csp_is_address_mine(uint8_t address);
 
 /** csp_set_hostname
  * Set subsystem hostname.

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -442,7 +442,7 @@ csp_packet_t * csp_recvfrom(csp_socket_t * socket, uint32_t timeout) {
 
 }
 
-int csp_sendto(uint8_t prio, uint8_t dest, uint8_t dport, uint8_t src_port, uint32_t opts, csp_packet_t * packet, uint32_t timeout) {
+int csp_sendto_from(uint8_t prio, uint8_t dest, uint8_t dport, uint8_t src, uint8_t src_port, uint32_t opts, csp_packet_t * packet, uint32_t timeout) {
 
 	packet->id.flags = 0;
 
@@ -480,7 +480,7 @@ int csp_sendto(uint8_t prio, uint8_t dest, uint8_t dport, uint8_t src_port, uint
 
 	packet->id.dst = dest;
 	packet->id.dport = dport;
-	packet->id.src = my_address;
+	packet->id.src = src;
 	packet->id.sport = src_port;
 	packet->id.pri = prio;
 
@@ -492,9 +492,18 @@ int csp_sendto(uint8_t prio, uint8_t dest, uint8_t dport, uint8_t src_port, uint
 
 }
 
+
+int csp_sendto(uint8_t prio, uint8_t dest, uint8_t dport, uint8_t src_port, uint32_t opts, csp_packet_t * packet, uint32_t timeout) {
+	return csp_sendto_from(prio, dest, dport, my_address, src_port, opts, packet, timeout);
+}
+
 int csp_sendto_reply(csp_packet_t * request_packet, csp_packet_t * reply_packet, uint32_t opts, uint32_t timeout) {
 	if (request_packet == NULL)
 		return CSP_ERR_INVAL;
 
-	return csp_sendto(request_packet->id.pri, request_packet->id.src, request_packet->id.sport, request_packet->id.dport, opts, reply_packet, timeout);
+	return csp_sendto_from(
+		request_packet->id.pri,
+		request_packet->id.src, request_packet->id.sport,
+		request_packet->id.dst, request_packet->id.dport,
+		opts, reply_packet, timeout);
 }

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -501,9 +501,16 @@ int csp_sendto_reply(csp_packet_t * request_packet, csp_packet_t * reply_packet,
 	if (request_packet == NULL)
 		return CSP_ERR_INVAL;
 
+	uint8_t src;
+	if (packet->id.dst == CSP_BROADCAST_ADDR) {
+		src = my_address;
+	} else {
+		src = packet->id.dst;
+	}
+
 	return csp_sendto_from(
 		request_packet->id.pri,
 		request_packet->id.src, request_packet->id.sport,
-		request_packet->id.dst, request_packet->id.dport,
+		src, request_packet->id.dport,
 		opts, reply_packet, timeout);
 }

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -1,7 +1,7 @@
 /*
 Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
 Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
-Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk) 
+Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk)
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -162,10 +162,9 @@ int csp_route_work(uint32_t timeout) {
 		return 0;
 	}
 #endif
-
+	
 	/* If the message is not to me, route the message to the correct interface */
-	if ((packet->id.dst != my_address) && (packet->id.dst != CSP_BROADCAST_ADDR)) {
-
+	if ((!csp_is_address_mine(packet->id.dst)) && (packet->id.dst != CSP_BROADCAST_ADDR)) {
 		/* Find the destination interface */
 		csp_iface_t * dstif = csp_rtable_find_iface(packet->id.dst);
 
@@ -223,7 +222,7 @@ int csp_route_work(uint32_t timeout) {
 		/* New incoming connection accepted */
 		csp_id_t idout;
 		idout.pri   = packet->id.pri;
-		idout.src   = my_address;
+		idout.src   = packet->id.dst;
 
 		idout.dst   = packet->id.src;
 		idout.dport = packet->id.sport;

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -162,7 +162,7 @@ int csp_route_work(uint32_t timeout) {
 		return 0;
 	}
 #endif
-	
+
 	/* If the message is not to me, route the message to the correct interface */
 	if ((!csp_is_address_mine(packet->id.dst)) && (packet->id.dst != CSP_BROADCAST_ADDR)) {
 		/* Find the destination interface */
@@ -222,7 +222,12 @@ int csp_route_work(uint32_t timeout) {
 		/* New incoming connection accepted */
 		csp_id_t idout;
 		idout.pri   = packet->id.pri;
-		idout.src   = packet->id.dst;
+		if (packet->id.dst == CSP_BROADCAST_ADDR) {
+			idout.src = my_address;
+		} else {
+			idout.src = packet->id.dst;
+		}
+
 
 		idout.dst   = packet->id.src;
 		idout.dport = packet->id.sport;

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -222,6 +222,7 @@ int csp_route_work(uint32_t timeout) {
 		/* New incoming connection accepted */
 		csp_id_t idout;
 		idout.pri   = packet->id.pri;
+
 		if (packet->id.dst == CSP_BROADCAST_ADDR) {
 			idout.src = my_address;
 		} else {

--- a/src/interfaces/csp_if_lo.c
+++ b/src/interfaces/csp_if_lo.c
@@ -1,7 +1,7 @@
 /*
 Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
 Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
-Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk) 
+Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk)
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -41,7 +41,7 @@ int csp_lo_tx(csp_iface_t * interface, csp_packet_t * packet, uint32_t timeout) 
 	 * blackhole routing addresses by setting their nexthop to
 	 * the loopback interface.
 	 */
-	if (packet->id.dst != my_address) {
+	if (!csp_is_address_mine(packet->id.dst)) {
 		/* Consume and drop packet */
 		csp_buffer_free(packet);
 		return CSP_ERR_NONE;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 ROOT=`git rev-parse --show-toplevel`
-(cd $ROOT;
-./waf configure --build-tests --enable-examples;
+(cd $ROOT &&
+./waf configure --build-tests --enable-examples &&
 ./waf
 )
-
+if [ $? -ne 0 ]; then
+    exit $?
+fi
 $ROOT/build/tester server &
 SERVER=$!
 $ROOT/build/tester client

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+ROOT=`git rev-parse --show-toplevel`
+(cd $ROOT;
+./waf configure --build-tests --enable-examples;
+./waf
+)
+
+$ROOT/build/tester server &
+SERVER=$!
+$ROOT/build/tester client
+kill -9 $SERVER

--- a/tests/tester.c
+++ b/tests/tester.c
@@ -1,0 +1,290 @@
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include <csp/csp.h>
+#include <csp/csp_interface.h>
+
+#define TYPE_SERVER 1
+#define TYPE_CLIENT 2
+#define CLIENT_NODE_ID 1
+#define SERVER_NODE_ID 2
+#define DYNAMIC_NODE_ID 3
+#define PORT        10
+#define BUF_SIZE    250
+
+pthread_t rx_thread;
+int rx_channel, tx_channel;
+
+int csp_fifo_tx(csp_iface_t *ifc, csp_packet_t *packet, uint32_t timeout);
+
+csp_iface_t csp_if_fifo = {
+    .name = "fifo",
+    .nexthop = csp_fifo_tx,
+    .mtu = BUF_SIZE,
+};
+
+int csp_fifo_tx(csp_iface_t *ifc, csp_packet_t *packet, uint32_t timeout) {
+    /* Write packet to fifo */
+    if (write(tx_channel, &packet->length, packet->length + sizeof(uint32_t) + sizeof(uint16_t)) < 0)
+        printf("Failed to write frame\r\n");
+    csp_buffer_free(packet);
+    return CSP_ERR_NONE;
+}
+
+void * fifo_rx(void * parameters) {
+    csp_packet_t *buf = csp_buffer_get(BUF_SIZE);
+    /* Wait for packet on fifo */
+    while (read(rx_channel, &buf->length, BUF_SIZE) > 0) {
+        csp_new_packet(buf, &csp_if_fifo, NULL);
+        buf = csp_buffer_get(BUF_SIZE);
+    }
+
+    return NULL;
+}
+
+/* Build a packet with a null terminated payload */
+csp_packet_t *new_packet(char *data) {
+    size_t len = strlen(data);
+
+    csp_packet_t *packet = csp_buffer_get(len);
+    if (!packet) {
+        return NULL;
+    }
+
+    memcpy((char *) packet->data, data, len);
+    packet->length = len;
+
+    return packet;
+}
+
+int iscommand(csp_packet_t *packet, char *cmd) {
+    size_t len = strlen(cmd);
+
+    if (packet->length != len) {
+        return 0;
+    }
+
+    if (memcmp(packet->data, cmd, len) != 0) {
+        return 0;
+    }
+
+    return 1;
+}
+
+int command(csp_socket_t *sock, int target, char *command, char *expected) {
+    csp_packet_t *packet, *reply_packet;
+    packet = new_packet(command);
+    if (!packet) {
+        return -1;
+    }
+
+    if (csp_sendto(CSP_PRIO_NORM, target, PORT, PORT, CSP_SO_CONN_LESS, packet, 1000) != CSP_ERR_NONE) {
+        printf("Failed send\n");
+        return -1;
+    }
+
+    reply_packet = csp_recvfrom(sock, 1000);
+    if (!reply_packet) {
+        printf("Reply without packet\n");
+        return -1;
+    }
+    if (!iscommand(reply_packet, expected)) {
+        printf("Expected %s, got %s\n", expected, reply_packet->data);
+        return -1;
+    }
+    csp_buffer_free(reply_packet);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+
+    int me, other, type;
+    char *rx_channel_name, *tx_channel_name;
+    int ret = 0;
+    csp_socket_t *sock;
+    csp_packet_t *packet, *reply_packet;
+
+    /* Run as either server or client */
+    if (argc != 2) {
+        printf("usage: %s <server/client>\r\n", argv[0]);
+        return -1;
+    }
+
+    /* Set type */
+    if (strcmp(argv[1], "server") == 0) {
+        me = SERVER_NODE_ID;
+        other = CLIENT_NODE_ID;
+        tx_channel_name = "server_to_client";
+        rx_channel_name = "client_to_server";
+        type = TYPE_SERVER;
+    } else if (strcmp(argv[1], "client") == 0) {
+        me = CLIENT_NODE_ID;
+        other = SERVER_NODE_ID;
+        tx_channel_name = "client_to_server";
+        rx_channel_name = "server_to_client";
+        type = TYPE_CLIENT;
+    } else {
+        printf("Invalid type. Must be either 'server' or 'client'\r\n");
+        return -1;
+    }
+
+    /* Init CSP and CSP buffer system */
+    if (csp_init(me) != CSP_ERR_NONE || csp_buffer_init(10, 300) != CSP_ERR_NONE) {
+        printf("Failed to init CSP\r\n");
+        return -1;
+    }
+
+    ret = mkfifo(rx_channel_name, S_IRUSR | S_IWUSR);
+    if (-1 == ret && EEXIST != errno) {
+        perror("could not mkfifo for rx");
+        return -1;
+    }
+    ret = mkfifo(tx_channel_name, S_IWUSR | S_IRUSR);
+    if (-1 == ret && EEXIST != errno) {
+        perror("could not mkfifo for tx");
+        return -1;
+    }
+
+    tx_channel = open(tx_channel_name, O_RDWR);
+    if (tx_channel < 0) {
+        printf("Failed to open TX channel\r\n");
+        return -1;
+    }
+
+    rx_channel = open(rx_channel_name, O_RDWR);
+    if (rx_channel < 0) {
+        printf("Failed to open RX channel\r\n");
+        return -1;
+    }
+
+    /* Start fifo RX task */
+	pthread_create(&rx_thread, NULL, fifo_rx, NULL);
+
+    /* Set default route and start router */
+    csp_route_set(CSP_DEFAULT_ROUTE, &csp_if_fifo, CSP_NODE_MAC);
+    csp_route_start_task(0, 0);
+    sock = csp_socket(CSP_SO_CONN_LESS);
+    csp_bind(sock, PORT);
+
+    if (type == TYPE_SERVER) {
+        while (true) {
+        /* Process incoming packet */
+
+            packet = csp_recvfrom(sock, 1000);
+            if (packet) {
+                printf("Received: %s\r\n", packet->data);
+                if (iscommand(packet, "ping")) {
+                    reply_packet = new_packet("pong");
+                    if (!reply_packet) {
+                        return -1;
+                    }
+                    csp_sendto(CSP_PRIO_NORM, other, PORT, PORT, CSP_SO_CONN_LESS, reply_packet, 1000);
+
+                }
+                if (iscommand(packet, "enable")) {
+                    if (csp_enable_dynamic_address(DYNAMIC_NODE_ID) == CSP_ERR_NONE) {
+                        reply_packet = new_packet("ok");
+                    } else {
+                        reply_packet = new_packet("error");
+                    }
+                    if (!reply_packet) {
+                        return -1;
+                    }
+                    csp_sendto(CSP_PRIO_NORM, other, PORT, PORT, CSP_SO_CONN_LESS, reply_packet, 1000);
+
+                }
+                if (iscommand(packet, "disable")) {
+                    if (csp_disable_dynamic_address() == CSP_ERR_NONE) {
+                        reply_packet = new_packet("ok");
+                    } else {
+                        reply_packet = new_packet("error");
+                    }                    
+                    if (!reply_packet) {
+                        return -1;
+                    }
+                    csp_sendto(CSP_PRIO_NORM, other, PORT, PORT, CSP_SO_CONN_LESS, reply_packet, 1000);
+
+                }
+                csp_buffer_free(packet);
+            }
+
+        }
+    } else {
+        /* Test echo: send ping, get pong */
+        printf("Test CSP Echo: ");
+        if (command(sock, SERVER_NODE_ID, "ping", "pong") != 0) {
+            return -1;
+        }
+        printf("OK\n");
+
+        /* Test dynamic timeout: send ping to dynamic address, get nothing */
+        printf("Test Dynamic ping timeout: ");
+        packet = new_packet("ping");
+        if (!packet) {
+            return -1;
+        }
+
+        if (csp_sendto(CSP_PRIO_NORM, DYNAMIC_NODE_ID, PORT, PORT, CSP_SO_CONN_LESS, packet, 1000) != CSP_ERR_NONE) {
+            printf("Failed send\n");
+            return -1;
+        }
+
+        reply_packet = csp_recvfrom(sock, 1000);
+        if (reply_packet) {
+            printf("Unexpected reply\n");
+            return -1;
+        }
+        printf("OK\n");
+
+        /* Test dynamic ping: enable dynamic address, get ping reply */
+        printf("Test Enable Dynamic Address: ");
+        if (command(sock, SERVER_NODE_ID, "enable", "ok") != 0) {
+            return -1;
+        }
+        printf("OK\n");
+
+        printf("Test Dynamic Address Ping: ");
+        if (command(sock, DYNAMIC_NODE_ID, "ping", "pong") != 0) {
+            return -1;
+        }
+        printf("OK\n");
+
+        /* Test disblae dynamic ping: disable dynamic address, dont get ping reply */
+        printf("Test disable Dynamic Address: ");
+        if (command(sock, SERVER_NODE_ID, "disable", "ok") != 0) {
+            return -1;
+        }
+        printf("OK\n");
+
+        printf("Test Dynamic Address Ping: ");
+        packet = new_packet("ping");
+        if (!packet) {
+            return -1;
+        }
+
+        if (csp_sendto(CSP_PRIO_NORM, DYNAMIC_NODE_ID, PORT, PORT, CSP_SO_CONN_LESS, packet, 1000) != CSP_ERR_NONE) {
+            printf("Failed send\n");
+            return -1;
+        }
+
+        reply_packet = csp_recvfrom(sock, 1000);
+        if (reply_packet) {
+            printf("Unexpected reply\n");
+            return -1;
+        }
+        printf("OK\n");
+
+    }
+
+    close(rx_channel);
+    close(tx_channel);
+
+    return 0;
+}

--- a/tests/tester.c
+++ b/tests/tester.c
@@ -95,6 +95,10 @@ int command(csp_socket_t *sock, int target, char *command, char *expected) {
         printf("Reply without packet\n");
         return -1;
     }
+    if (reply_packet->id.src != target) {
+        printf("Reply from different host\n");
+        return -1;
+    }
     if (!iscommand(reply_packet, expected)) {
         printf("Expected %s, got %s\n", expected, reply_packet->data);
         return -1;
@@ -105,7 +109,7 @@ int command(csp_socket_t *sock, int target, char *command, char *expected) {
 
 int main(int argc, char **argv) {
 
-    int me, other, type;
+    int me, type;
     char *rx_channel_name, *tx_channel_name;
     int ret = 0;
     csp_socket_t *sock;
@@ -120,13 +124,11 @@ int main(int argc, char **argv) {
     /* Set type */
     if (strcmp(argv[1], "server") == 0) {
         me = SERVER_NODE_ID;
-        other = CLIENT_NODE_ID;
         tx_channel_name = "server_to_client";
         rx_channel_name = "client_to_server";
         type = TYPE_SERVER;
     } else if (strcmp(argv[1], "client") == 0) {
         me = CLIENT_NODE_ID;
-        other = SERVER_NODE_ID;
         tx_channel_name = "client_to_server";
         rx_channel_name = "server_to_client";
         type = TYPE_CLIENT;
@@ -185,7 +187,7 @@ int main(int argc, char **argv) {
                     if (!reply_packet) {
                         return -1;
                     }
-                    csp_sendto(CSP_PRIO_NORM, other, PORT, PORT, CSP_SO_CONN_LESS, reply_packet, 1000);
+                    csp_sendto_reply(packet, reply_packet, CSP_PRIO_NORM, 1000);
 
                 }
                 if (iscommand(packet, "enable")) {
@@ -197,7 +199,7 @@ int main(int argc, char **argv) {
                     if (!reply_packet) {
                         return -1;
                     }
-                    csp_sendto(CSP_PRIO_NORM, other, PORT, PORT, CSP_SO_CONN_LESS, reply_packet, 1000);
+                    csp_sendto_reply(packet, reply_packet, CSP_PRIO_NORM, 1000);
 
                 }
                 if (iscommand(packet, "disable")) {
@@ -205,11 +207,11 @@ int main(int argc, char **argv) {
                         reply_packet = new_packet("ok");
                     } else {
                         reply_packet = new_packet("error");
-                    }                    
+                    }
                     if (!reply_packet) {
                         return -1;
                     }
-                    csp_sendto(CSP_PRIO_NORM, other, PORT, PORT, CSP_SO_CONN_LESS, reply_packet, 1000);
+                    csp_sendto_reply(packet, reply_packet, CSP_PRIO_NORM, 1000);
 
                 }
                 csp_buffer_free(packet);

--- a/wscript
+++ b/wscript
@@ -3,7 +3,7 @@
 
 # Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
 # Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
-# Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk) 
+# Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk)
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -17,297 +17,358 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301  USA
 
 import os
 
 APPNAME = 'libcsp'
 VERSION = '1.4'
 
-top	= '.'
-out	= 'build'
+top = '.'
+out = 'build'
+
 
 def options(ctx):
-	# Load GCC options
-	ctx.load('gcc')
-	
-	ctx.add_option('--toolchain', default=None, help='Set toolchain prefix')
+    # Load GCC options
+    ctx.load('gcc')
 
-	# Set libcsp options
-	gr = ctx.add_option_group('libcsp options')
-	gr.add_option('--includes', default='', help='Add additional include paths. Separate with comma')
-	gr.add_option('--install-csp', action='store_true', help='Installs CSP headers and lib')
+    ctx.add_option('--toolchain', default=None, help='Set toolchain prefix')
 
-	gr.add_option('--disable-output', action='store_true', help='Disable CSP output')
-	gr.add_option('--disable-stlib', action='store_true', help='Build objects only')
-	gr.add_option('--enable-rdp', action='store_true', help='Enable RDP support')
-	gr.add_option('--enable-qos', action='store_true', help='Enable Quality of Service support')
-	gr.add_option('--enable-promisc', action='store_true', help='Enable promiscuous mode support')
-	gr.add_option('--enable-crc32', action='store_true', help='Enable CRC32 support')
-	gr.add_option('--enable-hmac', action='store_true', help='Enable HMAC-SHA1 support')
-	gr.add_option('--enable-xtea', action='store_true', help='Enable XTEA support')
-	gr.add_option('--enable-bindings', action='store_true', help='Enable Python bindings')
-	gr.add_option('--enable-examples', action='store_true', help='Enable examples')
-	gr.add_option('--enable-dedup', action='store_true', help='Enable packet deduplicator')
-	gr.add_option('--enable-verbose', action='store_true', help='Enable filename and line numbers on debug');
+    # Set libcsp options
+    gr = ctx.add_option_group('libcsp options')
+    gr.add_option('--includes', default='',
+                  help='Add additional include paths. Separate with comma')
+    gr.add_option('--install-csp', action='store_true',
+                  help='Installs CSP headers and lib')
 
-	# Interfaces	
-	gr.add_option('--enable-if-i2c', action='store_true', help='Enable I2C interface')
-	gr.add_option('--enable-if-kiss', action='store_true', help='Enable KISS/RS.232 interface')
-	gr.add_option('--enable-if-can', action='store_true', help='Enable CAN interface')
-	gr.add_option('--enable-if-zmqhub', action='store_true', help='Enable ZMQHUB interface')
-	
-	# Drivers
-	gr.add_option('--with-driver-can', default=None, metavar='CHIP', help='Build CAN driver. [socketcan, at91sam7a1, at91sam7a3 or at90can128]')
-	gr.add_option('--with-driver-usart', default=None, metavar='DRIVER', help='Build USART driver. [windows, linux, None]')
-	gr.add_option('--with-drivers', metavar='PATH', default=None, help='Set path to Driver header files')
+    gr.add_option('--disable-output', action='store_true',
+                  help='Disable CSP output')
+    gr.add_option('--disable-stlib', action='store_true',
+                  help='Build objects only')
+    gr.add_option('--enable-rdp', action='store_true',
+                  help='Enable RDP support')
+    gr.add_option('--enable-qos', action='store_true',
+                  help='Enable Quality of Service support')
+    gr.add_option('--enable-promisc', action='store_true',
+                  help='Enable promiscuous mode support')
+    gr.add_option('--enable-crc32', action='store_true',
+                  help='Enable CRC32 support')
+    gr.add_option('--enable-hmac', action='store_true',
+                  help='Enable HMAC-SHA1 support')
+    gr.add_option('--enable-xtea', action='store_true',
+                  help='Enable XTEA support')
+    gr.add_option('--enable-bindings', action='store_true',
+                  help='Enable Python bindings')
+    gr.add_option('--enable-examples', action='store_true',
+                  help='Enable examples')
+    gr.add_option('--enable-dedup', action='store_true',
+                  help='Enable packet deduplicator')
+    gr.add_option('--enable-verbose', action='store_true',
+                  help='Enable filename and line numbers on debug')
 
-	# OS	
-	gr.add_option('--with-os', metavar='OS', default='posix', help='Set operating system. Must be either \'posix\', \'macosx\', \'windows\' or \'freertos\'')
-	gr.add_option('--with-freertos', metavar='PATH', default=None, help='Set path to FreeRTOS header files')
-	gr.add_option('--enable-init-shutdown', action='store_true', help='Use init system commands for shutdown/reboot')
+    # Interfaces
+    gr.add_option('--enable-if-i2c', action='store_true',
+                  help='Enable I2C interface')
+    gr.add_option('--enable-if-kiss', action='store_true',
+                  help='Enable KISS/RS.232 interface')
+    gr.add_option('--enable-if-can', action='store_true',
+                  help='Enable CAN interface')
+    gr.add_option('--enable-if-zmqhub', action='store_true',
+                  help='Enable ZMQHUB interface')
 
-	# Options
-	gr.add_option('--with-rdp-max-window', metavar='SIZE', type=int, default=20, help='Set maximum window size for RDP')
-	gr.add_option('--with-max-bind-port', metavar='PORT', type=int, default=31, help='Set maximum bindable port')
-	gr.add_option('--with-max-connections', metavar='COUNT', type=int, default=10, help='Set maximum number of concurrent connections')
-	gr.add_option('--with-conn-queue-length', metavar='SIZE', type=int, default=100, help='Set maximum number of packets in queue for a connection')
-	gr.add_option('--with-router-queue-length', metavar='SIZE', type=int, default=10, help='Set maximum number of packets to be queued at the input of the router')
-	gr.add_option('--with-padding', metavar='BYTES', type=int, default=8, help='Set padding bytes before packet length field')
-	gr.add_option('--with-loglevel', metavar='LEVEL', default='debug', help='Set minimum compile time log level. Must be one of \'error\', \'warn\', \'info\' or \'debug\'')
-	gr.add_option('--with-rtable', metavar='TABLE', default='static', help='Set routing table type')
-	gr.add_option('--with-transaction-so', metavar='CSP_SO', type=int, default='0x0000', help='Set outgoing csp_transaction socket options, see csp.h for valid values')
-	gr.add_option('--with-bufalign', metavar='BYTES', type=int, help='Set buffer alignment')
+    # Drivers
+    gr.add_option('--with-driver-can', default=None, metavar='CHIP',
+                  help='Build CAN driver. [socketcan, at91sam7a1, at91sam7a3 or at90can128]')
+    gr.add_option('--with-driver-usart', default=None, metavar='DRIVER',
+                  help='Build USART driver. [windows, linux, None]')
+    gr.add_option('--with-drivers', metavar='PATH', default=None,
+                  help='Set path to Driver header files')
+
+    # OS
+    gr.add_option('--with-os', metavar='OS', default='posix',
+                  help='Set operating system. Must be either \'posix\', \'macosx\', \'windows\' or \'freertos\'')
+    gr.add_option('--with-freertos', metavar='PATH', default=None,
+                  help='Set path to FreeRTOS header files')
+    gr.add_option('--enable-init-shutdown', action='store_true',
+                  help='Use init system commands for shutdown/reboot')
+
+    # Options
+    gr.add_option('--with-rdp-max-window', metavar='SIZE', type=int,
+                  default=20, help='Set maximum window size for RDP')
+    gr.add_option('--with-max-bind-port', metavar='PORT', type=int,
+                  default=31, help='Set maximum bindable port')
+    gr.add_option('--with-max-connections', metavar='COUNT', type=int,
+                  default=10, help='Set maximum number of concurrent connections')
+    gr.add_option('--with-conn-queue-length', metavar='SIZE', type=int, default=100,
+                  help='Set maximum number of packets in queue for a connection')
+    gr.add_option('--with-router-queue-length', metavar='SIZE', type=int, default=10,
+                  help='Set maximum number of packets to be queued at the input of the router')
+    gr.add_option('--with-padding', metavar='BYTES', type=int,
+                  default=8, help='Set padding bytes before packet length field')
+    gr.add_option('--with-loglevel', metavar='LEVEL', default='debug',
+                  help='Set minimum compile time log level. Must be one of \'error\', \'warn\', \'info\' or \'debug\'')
+    gr.add_option('--with-rtable', metavar='TABLE',
+                  default='static', help='Set routing table type')
+    gr.add_option('--with-transaction-so', metavar='CSP_SO', type=int, default='0x0000',
+                  help='Set outgoing csp_transaction socket options, see csp.h for valid values')
+    gr.add_option('--with-bufalign', metavar='BYTES',
+                  type=int, help='Set buffer alignment')
+
 
 def configure(ctx):
-	# Validate OS
-	if not ctx.options.with_os in ('posix', 'windows', 'freertos', 'macosx'):
-		ctx.fatal('--with-os must be either \'posix\', \'windows\', \'macosx\' or \'freertos\'')
+    # Validate OS
+    if not ctx.options.with_os in ('posix', 'windows', 'freertos', 'macosx'):
+        ctx.fatal(
+            '--with-os must be either \'posix\', \'windows\', \'macosx\' or \'freertos\'')
 
-	# Validate CAN drivers
-	if not ctx.options.with_driver_can in (None, 'socketcan', 'at91sam7a1', 'at91sam7a3', 'at90can128'):
-		ctx.fatal('--with-driver-can must be either \'socketcan\', \'at91sam7a1\', \'at91sam7a3\', \'at90can128\'')
+    # Validate CAN drivers
+    if not ctx.options.with_driver_can in (None, 'socketcan', 'at91sam7a1', 'at91sam7a3', 'at90can128'):
+        ctx.fatal(
+            '--with-driver-can must be either \'socketcan\', \'at91sam7a1\', \'at91sam7a3\', \'at90can128\'')
 
-	# Validate USART drivers
-	if not ctx.options.with_driver_usart in (None, 'windows', 'linux'):
-		ctx.fatal('--with-driver-usart must be either \'windows\' or \'linux\'')
+    # Validate USART drivers
+    if not ctx.options.with_driver_usart in (None, 'windows', 'linux'):
+        ctx.fatal('--with-driver-usart must be either \'windows\' or \'linux\'')
 
-	if not ctx.options.with_loglevel in ('error', 'warn', 'info', 'debug'):
-		ctx.fatal('--with-loglevel must be either \'error\', \'warn\', \'info\' or \'debug\'')
+    if not ctx.options.with_loglevel in ('error', 'warn', 'info', 'debug'):
+        ctx.fatal(
+            '--with-loglevel must be either \'error\', \'warn\', \'info\' or \'debug\'')
 
-	# Setup and validate toolchain
-	if ctx.options.toolchain:
-		ctx.env.CC = ctx.options.toolchain + 'gcc'
-		ctx.env.AR = ctx.options.toolchain + 'ar'
+    # Setup and validate toolchain
+    if ctx.options.toolchain:
+        ctx.env.CC = ctx.options.toolchain + 'gcc'
+        ctx.env.AR = ctx.options.toolchain + 'ar'
 
-	ctx.load('gcc')
+    ctx.load('gcc')
 
-	# Set git revision define
-	git_rev = os.popen('git describe --always 2> /dev/null || echo unknown').read().strip()
+    # Set git revision define
+    git_rev = os.popen(
+        'git describe --always 2> /dev/null || echo unknown').read().strip()
 
-	# Setup DEFINES
-	ctx.define('GIT_REV', git_rev)
+    # Setup DEFINES
+    ctx.define('GIT_REV', git_rev)
 
-	# Set build output format
-	ctx.env.FEATURES = ['c']
-	if not ctx.options.disable_stlib:
-		ctx.env.FEATURES += ['cstlib']
+    # Set build output format
+    ctx.env.FEATURES = ['c']
+    if not ctx.options.disable_stlib:
+        ctx.env.FEATURES += ['cstlib']
 
-	# Setup CFLAGS
-	if (len(ctx.env.CFLAGS) == 0):
-		ctx.env.prepend_value('CFLAGS', ['-Os','-Wall', '-g', '-std=gnu99'])
+    # Setup CFLAGS
+    if (len(ctx.env.CFLAGS) == 0):
+        ctx.env.prepend_value('CFLAGS', ['-Os', '-Wall', '-g', '-std=gnu99'])
 
-	# Setup extra includes
-	ctx.env.append_unique('INCLUDES_CSP', ['include'] + ctx.options.includes.split(','))
+    # Setup extra includes
+    ctx.env.append_unique(
+        'INCLUDES_CSP', ['include'] + ctx.options.includes.split(','))
 
-	# Add default files
-	ctx.env.append_unique('FILES_CSP', ['src/*.c','src/interfaces/csp_if_lo.c','src/transport/csp_udp.c','src/arch/{0}/**/*.c'.format(ctx.options.with_os)])
-	
-	# Libs
-	if 'posix' in ctx.env.OS:
-		ctx.env.append_unique('LIBS', ['rt', 'pthread', 'util'])
-	elif 'macosx' in ctx.env.OS:
-		ctx.env.append_unique('LIBS', ['pthread'])
+    # Add default files
+    ctx.env.append_unique('FILES_CSP', ['src/*.c', 'src/interfaces/csp_if_lo.c',
+                                        'src/transport/csp_udp.c', 'src/arch/{0}/**/*.c'.format(ctx.options.with_os)])
 
-	# Check for recursion
-	if ctx.path == ctx.srcnode:
-		ctx.options.install_csp = True
-	
-	# Add FreeRTOS 
-	if ctx.options.with_os == 'freertos':
-		if ctx.options.with_freertos:
-			ctx.env.append_unique('INCLUDES_CSP', ctx.options.with_freertos)
-	elif ctx.options.with_os == 'windows':
-		ctx.env.append_unique('CFLAGS', ['-D_WIN32_WINNT=0x0600'])
-	
-	# Store OS as env variable
-	ctx.env.append_unique('OS', ctx.options.with_os)
+    # Libs
+    if 'posix' in ctx.env.OS:
+        ctx.env.append_unique('LIBS', ['rt', 'pthread', 'util'])
+    elif 'macosx' in ctx.env.OS:
+        ctx.env.append_unique('LIBS', ['pthread'])
 
-	ctx.define_cond('CSP_FREERTOS', ctx.options.with_os == 'freertos')
-	ctx.define_cond('CSP_POSIX', ctx.options.with_os == 'posix')
-	ctx.define_cond('CSP_WINDOWS', ctx.options.with_os == 'windows')
-	ctx.define_cond('CSP_MACOSX', ctx.options.with_os == 'macosx')
-		
-	# Add Eternal Drivers
-	if ctx.options.with_drivers:
-		ctx.env.append_unique('INCLUDES_CSP', ctx.options.with_drivers)
+    # Check for recursion
+    if ctx.path == ctx.srcnode:
+        ctx.options.install_csp = True
 
-	# Add CAN driver
-	if ctx.options.with_driver_can:
-		ctx.env.append_unique('FILES_CSP', 'src/drivers/can/can_{0}.c'.format(ctx.options.with_driver_can))
+    # Add FreeRTOS
+    if ctx.options.with_os == 'freertos':
+        if ctx.options.with_freertos:
+            ctx.env.append_unique('INCLUDES_CSP', ctx.options.with_freertos)
+    elif ctx.options.with_os == 'windows':
+        ctx.env.append_unique('CFLAGS', ['-D_WIN32_WINNT=0x0600'])
 
-	# Add USART driver
-	if ctx.options.with_driver_usart != None:
-		ctx.env.append_unique('FILES_CSP', 'src/drivers/usart/usart_{0}.c'.format(ctx.options.with_driver_usart))
-		
-	# Interfaces
-	if ctx.options.enable_if_can:
-		ctx.env.append_unique('FILES_CSP', 'src/interfaces/csp_if_can.c')
-	if ctx.options.enable_if_i2c:
-		ctx.env.append_unique('FILES_CSP', 'src/interfaces/csp_if_i2c.c')
-	if ctx.options.enable_if_kiss:
-		ctx.env.append_unique('FILES_CSP', 'src/interfaces/csp_if_kiss.c')
-	if ctx.options.enable_if_zmqhub:
-		ctx.env.append_unique('FILES_CSP', 'src/interfaces/csp_if_zmqhub.c')
-		ctx.check_cfg(package='libzmq', args='--cflags --libs')
-		ctx.env.append_unique('LIBS', ctx.env.LIB_LIBZMQ)
+    # Store OS as env variable
+    ctx.env.append_unique('OS', ctx.options.with_os)
 
-	# Store configuration options
-	ctx.env.ENABLE_BINDINGS = ctx.options.enable_bindings
-	ctx.env.ENABLE_EXAMPLES = ctx.options.enable_examples
-	
-	# Create config file
-	if not ctx.options.disable_output:
-		ctx.env.append_unique('FILES_CSP', 'src/csp_debug.c')
-	else:
-		ctx.env.append_unique('EXCL_CSP', 'src/csp_debug.c')
+    ctx.define_cond('CSP_FREERTOS', ctx.options.with_os == 'freertos')
+    ctx.define_cond('CSP_POSIX', ctx.options.with_os == 'posix')
+    ctx.define_cond('CSP_WINDOWS', ctx.options.with_os == 'windows')
+    ctx.define_cond('CSP_MACOSX', ctx.options.with_os == 'macosx')
 
-	if ctx.options.enable_rdp:
-		ctx.env.append_unique('FILES_CSP', 'src/transport/csp_rdp.c')
+    # Add Eternal Drivers
+    if ctx.options.with_drivers:
+        ctx.env.append_unique('INCLUDES_CSP', ctx.options.with_drivers)
 
-	if ctx.options.enable_crc32:
-		ctx.env.append_unique('FILES_CSP', 'src/csp_crc32.c')
-	else:
-		ctx.env.append_unique('EXCL_CSP', 'src/csp_crc32.c')
+    # Add CAN driver
+    if ctx.options.with_driver_can:
+        ctx.env.append_unique(
+            'FILES_CSP', 'src/drivers/can/can_{0}.c'.format(ctx.options.with_driver_can))
 
-	if not ctx.options.enable_dedup:
-		ctx.env.append_unique('EXCL_CSP', 'src/csp_dedup.c')
+    # Add USART driver
+    if ctx.options.with_driver_usart != None:
+        ctx.env.append_unique(
+            'FILES_CSP', 'src/drivers/usart/usart_{0}.c'.format(ctx.options.with_driver_usart))
 
-	if ctx.options.enable_hmac:
-		ctx.env.append_unique('FILES_CSP', 'src/crypto/csp_hmac.c')
-		ctx.env.append_unique('FILES_CSP', 'src/crypto/csp_sha1.c')
+    # Interfaces
+    if ctx.options.enable_if_can:
+        ctx.env.append_unique('FILES_CSP', 'src/interfaces/csp_if_can.c')
+    if ctx.options.enable_if_i2c:
+        ctx.env.append_unique('FILES_CSP', 'src/interfaces/csp_if_i2c.c')
+    if ctx.options.enable_if_kiss:
+        ctx.env.append_unique('FILES_CSP', 'src/interfaces/csp_if_kiss.c')
+    if ctx.options.enable_if_zmqhub:
+        ctx.env.append_unique('FILES_CSP', 'src/interfaces/csp_if_zmqhub.c')
+        ctx.check_cfg(package='libzmq', args='--cflags --libs')
+        ctx.env.append_unique('LIBS', ctx.env.LIB_LIBZMQ)
 
-	if ctx.options.enable_xtea:
-		ctx.env.append_unique('FILES_CSP', 'src/crypto/csp_xtea.c')
-		ctx.env.append_unique('FILES_CSP', 'src/crypto/csp_sha1.c')
-		
-	ctx.env.append_unique('FILES_CSP', 'src/rtable/csp_rtable_' + ctx.options.with_rtable  + '.c')
+    # Store configuration options
+    ctx.env.ENABLE_BINDINGS = ctx.options.enable_bindings
+    ctx.env.ENABLE_EXAMPLES = ctx.options.enable_examples
 
-	ctx.define_cond('CSP_DEBUG', not ctx.options.disable_output)
-	ctx.define_cond('CSP_VERBOSE', ctx.options.enable_verbose);
-	ctx.define_cond('CSP_USE_RDP', ctx.options.enable_rdp)
-	ctx.define_cond('CSP_USE_CRC32', ctx.options.enable_crc32)
-	ctx.define_cond('CSP_USE_HMAC', ctx.options.enable_hmac)
-	ctx.define_cond('CSP_USE_XTEA', ctx.options.enable_xtea)
-	ctx.define_cond('CSP_USE_PROMISC', ctx.options.enable_promisc)
-	ctx.define_cond('CSP_USE_QOS', ctx.options.enable_qos)
-	ctx.define_cond('CSP_USE_DEDUP', ctx.options.enable_dedup)
-	ctx.define_cond('CSP_USE_INIT_SHUTDOWN', ctx.options.enable_init_shutdown)
-	ctx.define('CSP_CONN_MAX', ctx.options.with_max_connections)
-	ctx.define('CSP_CONN_QUEUE_LENGTH', ctx.options.with_conn_queue_length)
-	ctx.define('CSP_FIFO_INPUT', ctx.options.with_router_queue_length)
-	ctx.define('CSP_MAX_BIND_PORT', ctx.options.with_max_bind_port)
-	ctx.define('CSP_RDP_MAX_WINDOW', ctx.options.with_rdp_max_window)
-	ctx.define('CSP_PADDING_BYTES', ctx.options.with_padding)
-	ctx.define('CSP_TRANSACTION_SO', ctx.options.with_transaction_so)
-	
-	if ctx.options.with_bufalign != None:
-		ctx.define('CSP_BUFFER_ALIGN', ctx.options.with_bufalign)
+    # Create config file
+    if not ctx.options.disable_output:
+        ctx.env.append_unique('FILES_CSP', 'src/csp_debug.c')
+    else:
+        ctx.env.append_unique('EXCL_CSP', 'src/csp_debug.c')
 
-	# Set logging level
-	ctx.define_cond('CSP_LOG_LEVEL_DEBUG', ctx.options.with_loglevel in ('debug'))
-	ctx.define_cond('CSP_LOG_LEVEL_INFO', ctx.options.with_loglevel in ('debug', 'info'))
-	ctx.define_cond('CSP_LOG_LEVEL_WARN', ctx.options.with_loglevel in ('debug', 'info', 'warn'))
-	ctx.define_cond('CSP_LOG_LEVEL_ERROR', ctx.options.with_loglevel in ('debug', 'info', 'warn', 'error'))
+    if ctx.options.enable_rdp:
+        ctx.env.append_unique('FILES_CSP', 'src/transport/csp_rdp.c')
 
-	# Check compiler endianness
-	endianness = ctx.check_endianness()
-	ctx.define_cond('CSP_LITTLE_ENDIAN', endianness == 'little')
-	ctx.define_cond('CSP_BIG_ENDIAN', endianness == 'big')
+    if ctx.options.enable_crc32:
+        ctx.env.append_unique('FILES_CSP', 'src/csp_crc32.c')
+    else:
+        ctx.env.append_unique('EXCL_CSP', 'src/csp_crc32.c')
 
-	# Check for stdbool.h
-	ctx.check_cc(header_name='stdbool.h', mandatory=False, define_name='CSP_HAVE_STDBOOL_H', type='cstlib')
-	
-	ctx.define('LIBCSP_VERSION', VERSION)
+    if not ctx.options.enable_dedup:
+        ctx.env.append_unique('EXCL_CSP', 'src/csp_dedup.c')
 
-	ctx.write_config_header('include/csp/csp_autoconfig.h', top=True, remove=True)
-	
+    if ctx.options.enable_hmac:
+        ctx.env.append_unique('FILES_CSP', 'src/crypto/csp_hmac.c')
+        ctx.env.append_unique('FILES_CSP', 'src/crypto/csp_sha1.c')
+
+    if ctx.options.enable_xtea:
+        ctx.env.append_unique('FILES_CSP', 'src/crypto/csp_xtea.c')
+        ctx.env.append_unique('FILES_CSP', 'src/crypto/csp_sha1.c')
+
+    ctx.env.append_unique(
+        'FILES_CSP', 'src/rtable/csp_rtable_' + ctx.options.with_rtable + '.c')
+
+    ctx.define_cond('CSP_DEBUG', not ctx.options.disable_output)
+    ctx.define_cond('CSP_VERBOSE', ctx.options.enable_verbose)
+    ctx.define_cond('CSP_USE_RDP', ctx.options.enable_rdp)
+    ctx.define_cond('CSP_USE_CRC32', ctx.options.enable_crc32)
+    ctx.define_cond('CSP_USE_HMAC', ctx.options.enable_hmac)
+    ctx.define_cond('CSP_USE_XTEA', ctx.options.enable_xtea)
+    ctx.define_cond('CSP_USE_PROMISC', ctx.options.enable_promisc)
+    ctx.define_cond('CSP_USE_QOS', ctx.options.enable_qos)
+    ctx.define_cond('CSP_USE_DEDUP', ctx.options.enable_dedup)
+    ctx.define_cond('CSP_USE_INIT_SHUTDOWN', ctx.options.enable_init_shutdown)
+    ctx.define('CSP_CONN_MAX', ctx.options.with_max_connections)
+    ctx.define('CSP_CONN_QUEUE_LENGTH', ctx.options.with_conn_queue_length)
+    ctx.define('CSP_FIFO_INPUT', ctx.options.with_router_queue_length)
+    ctx.define('CSP_MAX_BIND_PORT', ctx.options.with_max_bind_port)
+    ctx.define('CSP_RDP_MAX_WINDOW', ctx.options.with_rdp_max_window)
+    ctx.define('CSP_PADDING_BYTES', ctx.options.with_padding)
+    ctx.define('CSP_TRANSACTION_SO', ctx.options.with_transaction_so)
+
+    if ctx.options.with_bufalign != None:
+        ctx.define('CSP_BUFFER_ALIGN', ctx.options.with_bufalign)
+
+    # Set logging level
+    ctx.define_cond('CSP_LOG_LEVEL_DEBUG',
+                    ctx.options.with_loglevel in ('debug'))
+    ctx.define_cond('CSP_LOG_LEVEL_INFO',
+                    ctx.options.with_loglevel in ('debug', 'info'))
+    ctx.define_cond('CSP_LOG_LEVEL_WARN',
+                    ctx.options.with_loglevel in ('debug', 'info', 'warn'))
+    ctx.define_cond('CSP_LOG_LEVEL_ERROR', ctx.options.with_loglevel in (
+        'debug', 'info', 'warn', 'error'))
+
+    # Check compiler endianness
+    endianness = ctx.check_endianness()
+    ctx.define_cond('CSP_LITTLE_ENDIAN', endianness == 'little')
+    ctx.define_cond('CSP_BIG_ENDIAN', endianness == 'big')
+
+    # Check for stdbool.h
+    ctx.check_cc(header_name='stdbool.h', mandatory=False,
+                 define_name='CSP_HAVE_STDBOOL_H', type='cstlib')
+
+    ctx.define('LIBCSP_VERSION', VERSION)
+
+    ctx.write_config_header(
+        'include/csp/csp_autoconfig.h', top=True, remove=True)
+
+
 def build(ctx):
 
-	# Set install path for header files
-	install_path = False
-	if ctx.options.install_csp:
-		install_path = '${PREFIX}/lib'
-		ctx.install_files('${PREFIX}/include/csp', ctx.path.ant_glob('include/csp/*.h'))
-		ctx.install_files('${PREFIX}/include/csp/interfaces', 'include/csp/interfaces/csp_if_lo.h')
+    # Set install path for header files
+    install_path = False
+    if ctx.options.install_csp:
+        install_path = '${PREFIX}/lib'
+        ctx.install_files('${PREFIX}/include/csp',
+                          ctx.path.ant_glob('include/csp/*.h'))
+        ctx.install_files('${PREFIX}/include/csp/interfaces',
+                          'include/csp/interfaces/csp_if_lo.h')
 
-		if 'src/interfaces/csp_if_can.c' in ctx.env.FILES_CSP:
-			ctx.install_files('${PREFIX}/include/csp/interfaces', 'include/csp/interfaces/csp_if_can.h')
-		if 'src/interfaces/csp_if_i2c.c' in ctx.env.FILES_CSP:
-			ctx.install_files('${PREFIX}/include/csp/interfaces', 'include/csp/interfaces/csp_if_i2c.h')
-		if 'src/interfaces/csp_if_kiss.c' in ctx.env.FILES_CSP:
-			ctx.install_files('${PREFIX}/include/csp/interfaces', 'include/csp/interfaces/csp_if_kiss.h')
-		if 'src/drivers/usart/usart_{0}.c'.format(ctx.options.with_driver_usart) in ctx.env.FILES_CSP:
-			ctx.install_as('${PREFIX}/include/csp/drivers/usart.h', 'include/csp/drivers/usart.h')
+        if 'src/interfaces/csp_if_can.c' in ctx.env.FILES_CSP:
+            ctx.install_files('${PREFIX}/include/csp/interfaces',
+                              'include/csp/interfaces/csp_if_can.h')
+        if 'src/interfaces/csp_if_i2c.c' in ctx.env.FILES_CSP:
+            ctx.install_files('${PREFIX}/include/csp/interfaces',
+                              'include/csp/interfaces/csp_if_i2c.h')
+        if 'src/interfaces/csp_if_kiss.c' in ctx.env.FILES_CSP:
+            ctx.install_files('${PREFIX}/include/csp/interfaces',
+                              'include/csp/interfaces/csp_if_kiss.h')
+        if 'src/drivers/usart/usart_{0}.c'.format(ctx.options.with_driver_usart) in ctx.env.FILES_CSP:
+            ctx.install_as('${PREFIX}/include/csp/drivers/usart.h',
+                           'include/csp/drivers/usart.h')
 
-		ctx.install_files('${PREFIX}/include/csp', 'include/csp/csp_autoconfig.h', cwd=ctx.bldnode)
+        ctx.install_files('${PREFIX}/include/csp',
+                          'include/csp/csp_autoconfig.h', cwd=ctx.bldnode)
 
-	ctx(export_includes='include', name='csp_h')
+    ctx(export_includes='include', name='csp_h')
 
-	ctx(features=ctx.env.FEATURES,
-		source=ctx.path.ant_glob(ctx.env.FILES_CSP, excl=ctx.env.EXCL_CSP),
-		target = 'csp',
-		includes= ctx.env.INCLUDES_CSP,
-		export_includes = ctx.env.INCLUDES_CSP,
-		use = 'include freertos_h',
-		install_path = install_path,
-	)
+    ctx(features=ctx.env.FEATURES,
+        source=ctx.path.ant_glob(ctx.env.FILES_CSP, excl=ctx.env.EXCL_CSP),
+        target='csp',
+        includes=ctx.env.INCLUDES_CSP,
+        export_includes=ctx.env.INCLUDES_CSP,
+        use='include freertos_h',
+        install_path=install_path,
+        )
 
-	# Build shared library for Python bindings
-	if ctx.env.ENABLE_BINDINGS:
-		ctx.shlib(source=ctx.path.ant_glob(ctx.env.FILES_CSP),
-			target = 'csp',
-			includes= ctx.env.INCLUDES_CSP,
-			export_includes = 'include',
-			use = ['include'],
-			lib = ctx.env.LIBS)
+    # Build shared library for Python bindings
+    if ctx.env.ENABLE_BINDINGS:
+        ctx.shlib(source=ctx.path.ant_glob(ctx.env.FILES_CSP),
+                  target='csp',
+                  includes=ctx.env.INCLUDES_CSP,
+                  export_includes='include',
+                  use=['include'],
+                  lib=ctx.env.LIBS)
 
-	if ctx.env.ENABLE_EXAMPLES:
-		ctx.program(source = ctx.path.ant_glob('examples/simple.c'),
-			target = 'simple',
-			includes = ctx.env.INCLUDES_CSP,
-			lib = ctx.env.LIBS,
-			use = 'csp')
+    if ctx.env.ENABLE_EXAMPLES:
+        ctx.program(source=ctx.path.ant_glob('examples/simple.c'),
+                    target='simple',
+                    includes=ctx.env.INCLUDES_CSP,
+                    lib=ctx.env.LIBS,
+                    use='csp')
 
-		if ctx.options.enable_if_kiss:
-			ctx.program(source = 'examples/kiss.c',
-				target = 'kiss',
-				includes = ctx.env.INCLUDES_CSP,
-				lib = libs,
-				use = 'csp')
+        if ctx.options.enable_if_kiss:
+            ctx.program(source='examples/kiss.c',
+                        target='kiss',
+                        includes=ctx.env.INCLUDES_CSP,
+                        lib=libs,
+                        use='csp')
 
-		if 'posix' in ctx.env.OS:
-			ctx.program(source = 'examples/csp_if_fifo.c',
-				target = 'fifo',
-				includes = ctx.env.INCLUDES_CSP,
-				lib = libs,
-				use = 'csp')
+        if 'posix' in ctx.env.OS:
+            ctx.program(source='examples/csp_if_fifo.c',
+                        target='fifo',
+                        includes=ctx.env.INCLUDES_CSP,
+                        lib=libs,
+                        use='csp')
 
-		if 'windows' in ctx.env.OS:
-			ctx.program(source = ctx.path.ant_glob('examples/csp_if_fifo_windows.c'),
-				target = 'csp_if_fifo',
-				includes = ctx.env.INCLUDES_CSP,
-				use = 'csp')
+        if 'windows' in ctx.env.OS:
+            ctx.program(source=ctx.path.ant_glob('examples/csp_if_fifo_windows.c'),
+                        target='csp_if_fifo',
+                        includes=ctx.env.INCLUDES_CSP,
+                        use='csp')
+
 
 def dist(ctx):
-	ctx.excl = 'build/* **/.* **/*.pyc **/*.o **/*~ *.tar.gz'
+    ctx.excl = 'build/* **/.* **/*.pyc **/*.o **/*~ *.tar.gz'

--- a/wscript
+++ b/wscript
@@ -62,6 +62,8 @@ def options(ctx):
                   help='Enable Python bindings')
     gr.add_option('--enable-examples', action='store_true',
                   help='Enable examples')
+    gr.add_option('--build-tests', action='store_true',
+                  help='Enable examples')
     gr.add_option('--enable-dedup', action='store_true',
                   help='Enable packet deduplicator')
     gr.add_option('--enable-verbose', action='store_true',
@@ -167,8 +169,10 @@ def configure(ctx):
                                         'src/transport/csp_udp.c', 'src/arch/{0}/**/*.c'.format(ctx.options.with_os)])
 
     # Libs
+    ctx.env.OS = ctx.options.with_os
     if 'posix' in ctx.env.OS:
         ctx.env.append_unique('LIBS', ['rt', 'pthread', 'util'])
+        print ("addedpthread!!!!")
     elif 'macosx' in ctx.env.OS:
         ctx.env.append_unique('LIBS', ['pthread'])
 
@@ -220,6 +224,7 @@ def configure(ctx):
     # Store configuration options
     ctx.env.ENABLE_BINDINGS = ctx.options.enable_bindings
     ctx.env.ENABLE_EXAMPLES = ctx.options.enable_examples
+    ctx.env.BUILD_TESTS = ctx.options.build_tests
 
     # Create config file
     if not ctx.options.disable_output:
@@ -353,20 +358,28 @@ def build(ctx):
             ctx.program(source='examples/kiss.c',
                         target='kiss',
                         includes=ctx.env.INCLUDES_CSP,
-                        lib=libs,
+                        lib=ctx.env.LIBS,
                         use='csp')
 
         if 'posix' in ctx.env.OS:
             ctx.program(source='examples/csp_if_fifo.c',
                         target='fifo',
                         includes=ctx.env.INCLUDES_CSP,
-                        lib=libs,
+                        lib=ctx.env.LIBS,
                         use='csp')
 
         if 'windows' in ctx.env.OS:
             ctx.program(source=ctx.path.ant_glob('examples/csp_if_fifo_windows.c'),
                         target='csp_if_fifo',
                         includes=ctx.env.INCLUDES_CSP,
+                        use='csp')
+
+    if ctx.env.BUILD_TESTS:
+        if 'posix' in ctx.env.OS:
+            ctx.program(source='tests/tester.c',
+                        target='tester',
+                        includes=ctx.env.INCLUDES_CSP,
+                        lib=ctx.env.LIBS,
                         use='csp')
 
 


### PR DESCRIPTION
CSP nodes can now get a dynamic node id.

Added functions:
- csp_sendto_from
- csp_enable_dynamic_address
- csp_disable_dynamic_address

I think this requires the interface to be in PROMISC mode.

Created some test infrastructure, minimal, but tests this feature.
Had to re indent all of wafscript, sorry about that.
